### PR TITLE
Fix empty functions bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1]
+
+### Fixed
+
+-   Fixed a bug where zero functions would create an `InvalidRequestError: [] is too short - 'functions'`
+
 ## [0.12.0]
 
 ### Added
 
-- A little chat function displayer
+-   A little chat function displayer
 
 ## [0.11.4]
 

--- a/murkrow/murkrow.py
+++ b/murkrow/murkrow.py
@@ -103,6 +103,7 @@ class Session:
         # We can replace in_function with chat_function_display is not None
 
         for result in resp:  # Go through the results of the stream
+            # TODO: Move this setup back into deltas
             choice = result['choices'][0]  # Get the first choice, since we're not doing bulk
 
             if 'delta' in choice:  # If there is a delta in the result

--- a/murkrow/murkrow.py
+++ b/murkrow/murkrow.py
@@ -73,6 +73,8 @@ class Session:
         Args:
             messages (str | Message): One or more messages to send to the chat, can be strings or Message objects.
 
+            auto_continue (bool): Whether to continue the conversation after the messages are sent. Defaults to the
+
         """
         self.append(*messages)
 

--- a/murkrow/murkrow.py
+++ b/murkrow/murkrow.py
@@ -80,11 +80,18 @@ class Session:
         mark = Markdown()
         mark.display()
 
+        # Don't pass in functions if there are none
+        chat_function_arguments = dict()
+        if len(self.function_registry.function_definitions) > 0:
+            chat_function_arguments = dict(
+                functions=self.function_registry.function_definitions,
+                function_call="auto",
+            )
+
         resp = openai.ChatCompletion.create(
             model=self.model,
             messages=self.messages,
-            functions=self.function_registry.function_definitions,
-            function_call="auto",
+            **chat_function_arguments,
             stream=True,
         )
 


### PR DESCRIPTION
I couldn't run the most basic `murkrow` session with zero functions because it would error with:

```
InvalidRequestError: [] is too short - 'functions'
```

OpenAI's API does not allow passing an empty collection of functions to their endpoint so we might as well work around that here.