### PR TITLE
Don't add in assistant messages if there isn't one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Don't emit empty assistant messages
+
 ## [0.12.2]
 
 ### Added

--- a/murkrow/murkrow.py
+++ b/murkrow/murkrow.py
@@ -115,10 +115,10 @@ class Session:
                     # Previous message finished
                     if not in_function:
                         # Wrap up the previous assistant message
-                        self.messages.append(assistant(mark.message))
-                        # TODO: With the CFD, we should toss the old markdown display
-                        mark = Markdown()
-                        mark.display()
+                        if mark.message.strip() != "":
+                            self.messages.append(assistant(mark.message))
+                            mark = Markdown()
+                            mark.display()
 
                         in_function = True
 


### PR DESCRIPTION
Sometimes there hasn't been an assistant message with content at all. This was previously erroneously adding in a contentless assistant message when the function was the first message.