### PR TITLE
allow json schema or schemaless* functions

### DIFF
--- a/murkrow/messaging.py
+++ b/murkrow/messaging.py
@@ -108,7 +108,7 @@ def system(content: str) -> Message:
     }
 
 
-def assistant_function_call(name: str, arguments: str) -> Message:
+def assistant_function_call(name: str, arguments: Optional[str]) -> Message:
     """Create a function call message."""
     return {
         'role': 'assistant',

--- a/murkrow/murkrow.py
+++ b/murkrow/murkrow.py
@@ -212,4 +212,7 @@ class Session:
             parameters_model (BaseModel): The pydantic model to use for parameters.
 
         """
-        self.function_registry.register(function, parameters_model, json_schema)
+        full_schema = self.function_registry.register(function, parameters_model, json_schema)
+
+        print("Created function with schema:")
+        print(json.dumps(full_schema, indent=2))

--- a/murkrow/murkrow.py
+++ b/murkrow/murkrow.py
@@ -202,7 +202,9 @@ class Session:
             else:
                 self.messages.append(message)
 
-    def register(self, function: Callable, parameters_model: "BaseModel"):
+    def register(
+        self, function: Callable, parameters_model: Optional["BaseModel"] = None, json_schema: Optional[dict] = None
+    ):
         """Register a function with the Murkrow instance.
 
         Args:
@@ -210,4 +212,4 @@ class Session:
             parameters_model (BaseModel): The pydantic model to use for parameters.
 
         """
-        self.function_registry.register(function, parameters_model)
+        self.function_registry.register(function, parameters_model, json_schema)

--- a/murkrow/murkrow.py
+++ b/murkrow/murkrow.py
@@ -1,6 +1,7 @@
 """Simple chatterbox."""
 
 import json
+import logging
 from typing import Callable, List, Optional, Union
 
 import openai
@@ -10,6 +11,8 @@ from murkrow.registry import FunctionRegistry
 
 from .display import ChatFunctionDisplay, Markdown
 from .messaging import Message, assistant, assistant_function_call, function_result, human
+
+logger = logging.getLogger(__name__)
 
 
 class Session:
@@ -214,5 +217,5 @@ class Session:
         """
         full_schema = self.function_registry.register(function, parameters_model, json_schema)
 
-        print("Created function with schema:")
-        print(json.dumps(full_schema, indent=2))
+        logger.debug("Created function with schema:")
+        logger.debug(json.dumps(full_schema, indent=2))

--- a/murkrow/registry.py
+++ b/murkrow/registry.py
@@ -110,6 +110,8 @@ def generate_function_schema(
             else:
                 raise Exception(f"Type annotation of parameter {name} in function {func_name} is not allowed")
 
+        schema = {"type": "object", "properties": {}, "required": []}
+        if len(schema_properties) > 0:
             schema = {
                 "type": "object",
                 "properties": schema_properties,

--- a/murkrow/registry.py
+++ b/murkrow/registry.py
@@ -41,12 +41,93 @@ Example usage:
 """
 
 import inspect
-from typing import Callable, Optional
+from typing import Callable, Optional, Union, get_args, get_origin
 
 from pydantic import BaseModel
 
 # Allowed types for auto-inferred schemas
 ALLOWED_TYPES = [int, str, bool, float, list, dict]
+
+JSON_SCHEMA_TYPES = {
+    int: 'integer',
+    float: 'number',
+    str: 'string',
+    bool: 'boolean',
+    list: 'array',
+    dict: 'object',
+}
+
+
+def is_optional_type(t):
+    """Check if a type is Optional."""
+    return get_origin(t) is Union and len(get_args(t)) == 2 and type(None) in get_args(t)
+
+
+def generate_function_schema(
+    function: Callable, parameters_model: Optional["BaseModel"] = None, json_schema: Optional[dict] = None
+):
+    """Generate a function schema for sending to OpenAI."""
+    doc = function.__doc__ or (parameters_model.__doc__ if parameters_model else None)
+    func_name = function.__name__
+
+    if not func_name:
+        raise Exception("Function must have a name")
+    if func_name == "<lambda>":
+        raise Exception("Lambda functions can only be used if their __name__ is set")
+    if not doc:
+        raise Exception("Function or parameter model must have a docstring")
+
+    schema = None
+    if json_schema:
+        schema = json_schema
+    elif parameters_model:
+        schema = parameters_model.schema()
+    else:
+        schema_properties = {}
+        sig = inspect.signature(function)
+        for name, param in sig.parameters.items():
+            if param.annotation == inspect.Parameter.empty:
+                raise Exception(f"Parameter {name} of function {func_name} must have a type annotation")
+
+            if is_optional_type(param.annotation):
+                actual_type = get_args(param.annotation)[0]
+
+                if actual_type not in ALLOWED_TYPES:
+                    raise Exception(
+                        f"Type annotation of parameter {name} in function {func_name} "
+                        f"must be a JSON serializable type ({ALLOWED_TYPES})"
+                    )
+
+                schema_properties[name] = {
+                    "type": JSON_SCHEMA_TYPES[actual_type],
+                }
+
+            elif param.annotation in ALLOWED_TYPES:
+                schema_properties[name] = {
+                    "type": JSON_SCHEMA_TYPES[param.annotation],
+                }
+
+            else:
+                raise Exception(f"Type annotation of parameter {name} in function {func_name} is not allowed")
+
+            schema = {
+                "type": "object",
+                "properties": schema_properties,
+                "required": [
+                    name
+                    for name, param in sig.parameters.items()
+                    if param.default == inspect.Parameter.empty and param.annotation != Optional
+                ],
+            }
+
+    if schema is None:
+        raise Exception(f"Could not generate schema for function {func_name}")
+
+    return {
+        "name": func_name,
+        "description": doc,
+        "parameters": schema,
+    }
 
 
 class FunctionRegistry:
@@ -64,47 +145,12 @@ class FunctionRegistry:
         self, function: Callable, parameters_model: Optional["BaseModel"] = None, json_schema: Optional[dict] = None
     ):
         """Register a function with a schema for sending to OpenAI."""
-        doc = function.__doc__ or parameters_model.__doc__ if parameters_model else None
-        name = function.__name__
-
-        if not name:
-            raise Exception("Function must have a name")
-        if name == "<lambda>":
-            raise Exception("Lambda functions can only be used if their __name__ is set")
-        if not doc:
-            raise Exception("Function or parameter model must have a docstring")
+        schema = generate_function_schema(function, parameters_model, json_schema)
 
         self.__functions[function.__name__] = function
+        self.__schemas[function.__name__] = schema
 
-        if json_schema:
-            schema = json_schema
-        elif parameters_model:
-            schema = parameters_model.schema()
-        else:
-            sig = inspect.signature(function)
-            for name, param in sig.parameters.items():
-                if param.annotation == inspect.Parameter.empty:
-                    raise Exception(f"Parameter {name} of function {function.__name__} must have a type annotation")
-                elif param.annotation not in ALLOWED_TYPES:
-                    raise Exception(
-                        f"Type annotation of parameter {name} in function {function.__name__} must"
-                        f" be a JSON serializable type ({ALLOWED_TYPES})"
-                    )
-            schema = {
-                "type": "object",
-                "properties": {
-                    name: {"type": str(param.annotation.__name__)} for name, param in sig.parameters.items()
-                },
-                "required": [
-                    name for name, param in sig.parameters.items() if param.default == inspect.Parameter.empty
-                ],
-            }
-
-        self.__schemas[function.__name__] = {
-            "name": name,
-            "description": doc,
-            "parameters": schema,
-        }
+        return schema
 
     def get(self, function_name):
         """Get a function by name."""


### PR DESCRIPTION
caveat: the function needs to be typed (use `typing`, folks!)

Now you can:

```python
import murkrow
import random

def flip_coin():
    '''flip a coin'''
    return random.choice(["heads", "tails"])

session = murkrow.Session(auto_continue=True)
session.register(flip_coin)

session.chat("Flip a coin")
```