### PR TITLE
Refactor function call object

### DIFF
--- a/murkrow/builtins.py
+++ b/murkrow/builtins.py
@@ -1,0 +1,23 @@
+"""Builtins for Murkrow."""
+from IPython.core.getipython import get_ipython
+
+
+def run_cell(code: str):
+    """Run Python code in the IPython kernel.
+
+    Sometimes the GPT Models hallucinate a function called `python`. This is a
+    rudimentary implementation of that function relying on IPython.
+
+    This could be further expanded to match what is in dangermode for an IPythonic combination
+    of stdout, stderr, exceptions, and rich output.
+    """
+    ip = get_ipython()
+    if ip is None:
+        raise Exception("Could not get IPython instance")
+
+    try:
+        output = ip.run_cell(code, silent=True)
+        return output.result
+    except Exception as e:
+        # We want the exception to be returned to the LLM
+        return e

--- a/murkrow/display.py
+++ b/murkrow/display.py
@@ -10,111 +10,16 @@ a few extra features.
 
 import os
 from binascii import hexlify
-from typing import Any, Dict, Iterator, Optional, Tuple, Union
+from typing import Optional
 
 from IPython.core import display_functions
 from vdom import details, div, span, style, summary
 
 from murkrow.registry import FunctionArgumentError, FunctionRegistry, UnknownFunctionError
 
+# Importing for the sake of backwards compatibility
+from .markdown import Markdown  # noqa: F401
 from .messaging import Message, function_result, system
-
-
-class Markdown:
-    """A class for displaying a markdown string that can be updated in place.
-
-    This class provides an easy way to create and update a Markdown string in Jupyter Notebooks. It
-    supports real-time updates of Markdown content which is useful for emitting ChatGPT suggestions
-    as they are generated.
-
-    Attributes:
-        message (str): The Markdown string to display
-
-    Example:
-        >>> from murkrow import Markdown
-        ...
-        >>> markdown = Markdown()
-        >>> markdown.append("Hello")
-        >>> markdown.append(" world!")
-        >>> markdown.display()
-        ```markdown
-        Hello world!
-        ```
-        >>> markdown.append(" This is an update!")
-        ```markdown
-        Hello world! This is an update!
-        ```
-        >>> def text_generator():
-        ...    yield " 1"
-        ...    yield " 2"
-        ...    yield " 3"
-        ...
-        >>> markdown.extend(text_generator())
-        ```markdown
-        Hello world! This is an update! 1 2 3
-        ```
-    """
-
-    def __init__(self, message: str = "") -> None:
-        """Initialize a `Markdown` object with an optional message."""
-        self._message: str = message
-        self._display_id: str = hexlify(os.urandom(8)).decode('ascii')
-
-    def append(self, delta: str) -> None:
-        """Append a string to the `Markdown`."""
-        self.message += delta
-
-    def extend(self, delta_generator: Iterator[str]) -> None:
-        """Extend the `Markdown` with a generator/iterator of strings."""
-        for delta in delta_generator:
-            self.append(delta)
-
-    # Alias consume
-    consume = extend
-
-    def display(self) -> None:
-        """Display the `Markdown` with a display ID for receiving updates."""
-        display_functions.display(self, display_id=self._display_id)
-
-    def update_displays(self) -> None:
-        """Force an update to all displays of this `Markdown`."""
-        display_functions.display(self, display_id=self._display_id, update=True)
-
-    @property
-    def metadata(self) -> Dict[str, Any]:
-        """Return the metadata for the `Markdown`."""
-        return {
-            "murkrow": {
-                "default": True,
-            }
-        }
-
-    def __repr__(self) -> str:
-        """Provide a plaintext version of the `Markdown`."""
-        message = self._message
-        if message is None or message == "":
-            message = " "
-        return message
-
-    def _repr_markdown_(self) -> Union[str, Tuple[str, Dict[str, Any]]]:
-        """Emit our markdown with metadata."""
-        message = self._message
-        # Handle some platforms that don't support empty Markdown
-        if message is None or message == "":
-            message = " "
-
-        return message, self.metadata
-
-    @property
-    def message(self) -> str:
-        """Return the `Markdown` message."""
-        return self._message
-
-    @message.setter
-    def message(self, value: str) -> None:
-        self._message = value
-        self.update_displays()
-
 
 # Palette used here is https://colorhunt.co/palette/27374d526d829db2bfdde6ed
 colors = {

--- a/murkrow/display.py
+++ b/murkrow/display.py
@@ -1,4 +1,4 @@
-"""display.py!
+"""display.py
 
 This module provides a `Markdown` class that works similarly to `IPython.display.Markdown` with
 a few extra features.
@@ -14,11 +14,11 @@ from binascii import hexlify
 from typing import Any, Dict, Iterator, Optional, Tuple, Union
 
 from IPython.core import display_functions
-from vdom import b, details, div, p, pre, span, style, summary
+from vdom import details, div, span, style, summary
 
 from murkrow.registry import FunctionRegistry
 
-from .messaging import Message, assistant, assistant_function_call, function_result, human, system
+from .messaging import Message, assistant_function_call, function_result, system
 
 
 class Markdown:
@@ -289,9 +289,13 @@ class ChatFunctionCall:
             try:
                 arguments = json.loads(function_args)
             except json.JSONDecodeError:
-                raise ValueError(f"Could not parse function arguments: {function_args}")
+                self.set_state("Error")
+                message_stack.append(system(f"Could not parse function arguments: {function_args}. They must be JSON."))
+                return message_stack
 
         # Execute the function and get the result
+        # TODO: Determine if we should do try/except or allow the developer to handle errors in their function
+        # Perhaps we should include handling as an additional option when registering a function?
         output = self.function_registry.call(function_name, arguments)
 
         repr_llm = repr(output)

--- a/murkrow/display.py
+++ b/murkrow/display.py
@@ -285,12 +285,13 @@ class ChatFunctionCall:
                 return message_stack
 
             try:
-                output = ip.run_cell(function_args)
+                output = ip.run_cell(function_args, silent=True)
+                repr_llm = repr(output.result)
+
                 self.set_state("Finished")
                 self.set_finished(True)
-
-                repr_llm = repr(output)
                 self.append_result(repr_llm)
+
                 message_stack.append(function_result(name="python", content=repr_llm))
                 return message_stack
 
@@ -325,7 +326,7 @@ class ChatFunctionCall:
 
         self.append_result(repr_llm)
         self.set_state("Ran")
-        self.set_finished()
+        self.set_finished(True)
 
         message_stack.append(function_result(name=function_name, content=repr_llm))
         return message_stack

--- a/murkrow/display.py
+++ b/murkrow/display.py
@@ -265,7 +265,6 @@ class ChatFunctionCall:
         function_name = self.function_name
         function_args = self.function_args
 
-        # TODO RETURN THE STACK, always
         message_stack: list[Message] = []
 
         # TODO: What I wish I had in this overall block was a way to `return` messages to the chat

--- a/murkrow/markdown.py
+++ b/murkrow/markdown.py
@@ -1,0 +1,108 @@
+"""An enhanced updateable Markdown display for use in Notebooks.
+
+* The `Markdown` display updates in place while messages are appended to it
+* The `Markdown` display can be updated from an iterator
+
+"""
+
+import os
+from binascii import hexlify
+from typing import Any, Dict, Iterator, Tuple, Union
+
+from IPython.core import display_functions
+
+
+class Markdown:
+    """A class for displaying a markdown string that can be updated in place.
+
+    This class provides an easy way to create and update a Markdown string in Jupyter Notebooks. It
+    supports real-time updates of Markdown content which is useful for emitting ChatGPT suggestions
+    as they are generated.
+
+    Attributes:
+        message (str): The Markdown string to display
+
+    Example:
+        >>> from murkrow import Markdown
+        ...
+        >>> markdown = Markdown()
+        >>> markdown.append("Hello")
+        >>> markdown.append(" world!")
+        >>> markdown.display()
+        ```markdown
+        Hello world!
+        ```
+        >>> markdown.append(" This is an update!")
+        ```markdown
+        Hello world! This is an update!
+        ```
+        >>> def text_generator():
+        ...    yield " 1"
+        ...    yield " 2"
+        ...    yield " 3"
+        ...
+        >>> markdown.extend(text_generator())
+        ```markdown
+        Hello world! This is an update! 1 2 3
+        ```
+    """
+
+    def __init__(self, message: str = "") -> None:
+        """Initialize a `Markdown` object with an optional message."""
+        self._message: str = message
+        self._display_id: str = hexlify(os.urandom(8)).decode('ascii')
+
+    def append(self, delta: str) -> None:
+        """Append a string to the `Markdown`."""
+        self.message += delta
+
+    def extend(self, delta_generator: Iterator[str]) -> None:
+        """Extend the `Markdown` with a generator/iterator of strings."""
+        for delta in delta_generator:
+            self.append(delta)
+
+    # Alias consume
+    consume = extend
+
+    def display(self) -> None:
+        """Display the `Markdown` with a display ID for receiving updates."""
+        display_functions.display(self, display_id=self._display_id)
+
+    def update_displays(self) -> None:
+        """Force an update to all displays of this `Markdown`."""
+        display_functions.display(self, display_id=self._display_id, update=True)
+
+    @property
+    def metadata(self) -> Dict[str, Any]:
+        """Return the metadata for the `Markdown`."""
+        return {
+            "murkrow": {
+                "default": True,
+            }
+        }
+
+    def __repr__(self) -> str:
+        """Provide a plaintext version of the `Markdown`."""
+        message = self._message
+        if message is None or message == "":
+            message = " "
+        return message
+
+    def _repr_markdown_(self) -> Union[str, Tuple[str, Dict[str, Any]]]:
+        """Emit our markdown with metadata."""
+        message = self._message
+        # Handle some platforms that don't support empty Markdown
+        if message is None or message == "":
+            message = " "
+
+        return message, self.metadata
+
+    @property
+    def message(self) -> str:
+        """Return the `Markdown` message."""
+        return self._message
+
+    @message.setter
+    def message(self, value: str) -> None:
+        self._message = value
+        self.update_displays()

--- a/murkrow/murkrow.py
+++ b/murkrow/murkrow.py
@@ -161,7 +161,7 @@ class Session:
                 return
 
             elif 'finish_reason' in choice and choice['finish_reason'] is not None:
-                if chat_function is not None:
+                if chat_function is None:
                     # Wrap up the previous assistant
                     self.messages.append(assistant(mark.message))
 

--- a/murkrow/murkrow.py
+++ b/murkrow/murkrow.py
@@ -31,7 +31,7 @@ class Session:
     >>> session.chat("How are you?")
     Hello!
     How are you?
-    >>> .chat("I'm fine, thanks.")
+    >>> session.chat("I'm fine, thanks.")
     Nice to hear!
 
     """


### PR DESCRIPTION
Broke the message handling around `call` out of the chat session object, deferring it to the object `ChatFunctionCall`.